### PR TITLE
Fix asset fingerprinting for dynamic gallery import

### DIFF
--- a/source/javascripts/cloudinary-tag-gallery.js
+++ b/source/javascripts/cloudinary-tag-gallery.js
@@ -43,6 +43,8 @@
     })
   })()
 
-  // Step 2: Import gallery
-  import("./gallery.js")
+  // Step 2: Import gallery after DOM is populated
+  const currentScript = document.querySelector('script[data-gallery-path]')
+  const galleryPath = currentScript.dataset.galleryPath
+  import(galleryPath)
 })()

--- a/source/lea.html.erb
+++ b/source/lea.html.erb
@@ -1,5 +1,5 @@
 <% content_for :assets do %>
-  <%= javascript_include_tag "cloudinary-tag-gallery", type: "module" %>
+  <%= javascript_include_tag "cloudinary-tag-gallery", type: "module", data: { gallery_path: asset_path(:js, "gallery.js") } %>
 <% end %>
 
 <div class="py-10vh bg-primary text-white">


### PR DESCRIPTION
## Summary
- Fixes production 404 error where hardcoded `gallery.js` import failed due to Middleman's asset fingerprinting
- Uses `asset_path(:js, "gallery.js")` to get the correct fingerprinted path via data attribute
- Maintains proper execution order by importing gallery after DOM population

## Test plan
- [x] Build succeeds with fingerprinted assets
- [x] Gallery script loads with correct fingerprinted path
- [x] No race condition between DOM population and gallery initialization

🤖 Generated with [Claude Code](https://claude.ai/code)